### PR TITLE
feat: add param path to launch

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -37,6 +37,8 @@
   <arg name="aeb_param_path"/>
   <arg name="predicted_path_checker_param_path"/>
   <arg name="collision_detector_param_path"/>
+  <arg name="control_command_gate_param_path"/>
+  <arg name="control_command_gate_naming_path"/>
 
   <!-- component -->
   <arg name="use_intra_process" default="false" description="use ROS 2 component container communication"/>
@@ -54,7 +56,10 @@
     <push-ros-namespace namespace="control"/>
 
     <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml"/>
+      <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml">
+        <arg name="config" value="$(var control_command_gate_param_path)"/>
+        <arg name="naming" value="$(var control_command_gate_naming_path)"/>
+      </include>
     </group>
     <group if="$(var use_control_command_gate)">
       <include file="$(find-pkg-share autoware_stop_mode_operator)/launch/stop_mode_operator.launch.xml"/>

--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -24,6 +24,10 @@
   <arg name="mrm_handler_param_path"/>
   <arg name="diagnostic_graph_aggregator_param_path"/>
   <arg name="diagnostic_graph_aggregator_graph_path"/>
+  <arg name="command_mode_switcher_param_path"/>
+  <arg name="command_mode_decider_param_path"/>
+  <arg name="change_operation_mode_srv" default="/system/operation_mode/change_operation_mode"/>
+  <arg name="change_autoware_control_srv" default="/system/operation_mode/change_autoware_control"/>
 
   <let name="sensor_launch_pkg" value="$(find-pkg-share $(var sensor_model)_launch)"/>
 
@@ -40,10 +44,16 @@
     <push-ros-namespace namespace="/system"/>
 
     <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_command_mode_switcher)/launch/switcher.launch.xml"/>
+      <include file="$(find-pkg-share autoware_command_mode_switcher)/launch/switcher.launch.xml">
+        <arg name="config" value="$(var command_mode_switcher_param_path)"/>
+      </include>
     </group>
     <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_command_mode_decider)/launch/decider.launch.xml"/>
+      <include file="$(find-pkg-share autoware_command_mode_decider)/launch/decider.launch.xml">
+        <arg name="config" value="$(var command_mode_decider_param_path)"/>
+        <arg name="~/operation_mode/change_operation_mode" value="$(var change_operation_mode_srv)"/>
+        <arg name="~/operation_mode/change_autoware_control" value="$(var change_autoware_control_srv)"/>
+      </include>
     </group>
 
     <!-- System Monitor -->


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
autoware_launchで指定したconfigを使用できるように修正。
deciderにサービスの名前の変数を追加している理由は、冗長構成になった場合、main ecu側もサービス名を変更しなくてはいけないから。

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
